### PR TITLE
Session 3: Add Migrations for Categories, Items, and Contacts Tables

### DIFF
--- a/database/migrations/2024_12_15_012523_create_categories_table.php
+++ b/database/migrations/2024_12_15_012523_create_categories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2024_12_15_012523_create_categories_table.php
+++ b/database/migrations/2024_12_15_012523_create_categories_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
     {
         Schema::create('categories', function (Blueprint $table) {
             $table->id();
+            $table->string('name', 50);
+            $table->string('description', 256)->nullable();
+            $table->boolean('condition')->default(1);
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_12_15_012934_create_items_table.php
+++ b/database/migrations/2024_12_15_012934_create_items_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('items', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('items');
+    }
+};

--- a/database/migrations/2024_12_15_012934_create_items_table.php
+++ b/database/migrations/2024_12_15_012934_create_items_table.php
@@ -13,7 +13,16 @@ return new class extends Migration
     {
         Schema::create('items', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('category_id');
+            $table->string('code', 50)->nullable();
+            $table->string('name', 100);
+            $table->integer('stock');
+            $table->string('description', 512)->nullable();
+            $table->string('image', 256)->nullable();
+            $table->boolean('status')->default(1);
             $table->timestamps();
+
+            $table->foreign('category_id')->references('id')->on('categories');
         });
     }
 

--- a/database/migrations/2024_12_15_013301_create_contacts_table.php
+++ b/database/migrations/2024_12_15_013301_create_contacts_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('contacts', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('contacts');
+    }
+};

--- a/database/migrations/2024_12_15_013301_create_contacts_table.php
+++ b/database/migrations/2024_12_15_013301_create_contacts_table.php
@@ -13,6 +13,13 @@ return new class extends Migration
     {
         Schema::create('contacts', function (Blueprint $table) {
             $table->id();
+            $table->string('type', 20);
+            $table->string('name', 100);
+            $table->string('document_type', 20);
+            $table->string('document_number', 20);
+            $table->string('address', 256)->nullable();
+            $table->string('phone', 20)->nullable();
+            $table->string('email', 100)->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Pull Request Summary

💾  **Categories Table Migration**: Added migration for the `categories` table and included columns for `name`, `description`, and `condition`.

💾  **Items Table Migration**: Added migration for the `items` table and included `category_id` and additional fields.

💾  **Contacts Table Migration**: Added migration for the `contacts` table and included additional fields.

:card_index: **Table Structures**: Defined the structure for `categories`, `items`, and `contacts` tables with appropriate columns and relationships.

:gear: **Database Schema**: Enhanced the database schema with new tables and fields to support categories, items, and contacts.
