### PR TITLE
Session 4: Add Migrations for Contacts, Customers, Suppliers, Incomes, and Sales Tables

### DIFF
--- a/database/migrations/2024_12_20_144652_rollback_create_contacts_table.php
+++ b/database/migrations/2024_12_20_144652_rollback_create_contacts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::create('contacts', function (Blueprint $table) {
+            $table->id();
+            $table->string('type', 20);
+            $table->string('name', 100);
+            $table->string('document_type', 20);
+            $table->string('document_number', 20);
+            $table->string('address', 256)->nullable();
+            $table->string('phone', 20)->nullable();
+            $table->string('email', 100)->nullable();
+            $table->timestamps();
+        });
+    }
+};

--- a/database/migrations/2024_12_20_144652_rollback_create_contacts_table.php
+++ b/database/migrations/2024_12_20_144652_rollback_create_contacts_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        //
+        Schema::dropIfExists('contacts');
     }
 
     /**

--- a/database/migrations/2024_12_20_145259_rb_create_contacts_table.php
+++ b/database/migrations/2024_12_20_145259_rb_create_contacts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2024_12_20_145259_rb_create_contacts_table.php
+++ b/database/migrations/2024_12_20_145259_rb_create_contacts_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        //
+        Schema::dropIfExists('contacts');
     }
 
     /**
@@ -19,6 +19,16 @@ return new class extends Migration
      */
     public function down(): void
     {
-        //
+        Schema::create('contacts', function (Blueprint $table) {
+            $table->id();
+            $table->string('type', 20);
+            $table->string('name', 100);
+            $table->string('document_type', 20);
+            $table->string('document_number', 20);
+            $table->string('address', 256)->nullable();
+            $table->string('phone', 20)->nullable();
+            $table->string('email', 100)->nullable();
+            $table->timestamps();
+        });
     }
 };

--- a/database/migrations/2024_12_20_151201_create_customers_table.php
+++ b/database/migrations/2024_12_20_151201_create_customers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('customers', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('customers');
+    }
+};

--- a/database/migrations/2024_12_20_151201_create_customers_table.php
+++ b/database/migrations/2024_12_20_151201_create_customers_table.php
@@ -13,6 +13,13 @@ return new class extends Migration
     {
         Schema::create('customers', function (Blueprint $table) {
             $table->id();
+            $table->string('name', 100);
+            $table->string('document_type', 20);
+            $table->string('document_number', 20);
+            $table->string('address', 256)->nullable();
+            $table->string('phone', 20)->nullable();
+            $table->string('email', 100)->nullable();
+            $table->boolean('status')->default(1);
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_12_20_151251_create_suppliers_table.php
+++ b/database/migrations/2024_12_20_151251_create_suppliers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('suppliers');
+    }
+};

--- a/database/migrations/2024_12_20_151251_create_suppliers_table.php
+++ b/database/migrations/2024_12_20_151251_create_suppliers_table.php
@@ -13,6 +13,13 @@ return new class extends Migration
     {
         Schema::create('suppliers', function (Blueprint $table) {
             $table->id();
+            $table->string('name', 100);
+            $table->string('document_type', 20);
+            $table->string('document_number', 20);
+            $table->string('address', 256)->nullable();
+            $table->string('phone', 20)->nullable();
+            $table->string('email', 100)->nullable();
+            $table->boolean('status')->default(1);
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_12_20_171938_create_incomes_table.php
+++ b/database/migrations/2024_12_20_171938_create_incomes_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('incomes', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('incomes');
+    }
+};

--- a/database/migrations/2024_12_20_171938_create_incomes_table.php
+++ b/database/migrations/2024_12_20_171938_create_incomes_table.php
@@ -13,6 +13,13 @@ return new class extends Migration
     {
         Schema::create('incomes', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('supplier_id');
+            $table->string('receipt_type', 20);
+            $table->string('receipt_series', 7)->nullable();
+            $table->string('receipt_number', 10);
+            $table->dateTime('date_time');
+            $table->decimal('tax', 4, 2);
+            $table->boolean('status')->default(1);
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_12_20_171938_create_incomes_table.php
+++ b/database/migrations/2024_12_20_171938_create_incomes_table.php
@@ -21,6 +21,8 @@ return new class extends Migration
             $table->decimal('tax', 4, 2);
             $table->boolean('status')->default(1);
             $table->timestamps();
+
+            $table->foreign('supplier_id')->references('id')->on('suppliers');
         });
     }
 

--- a/database/migrations/2024_12_20_172021_create_income_details_table.php
+++ b/database/migrations/2024_12_20_172021_create_income_details_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('income_details', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('income_details');
+    }
+};

--- a/database/migrations/2024_12_20_172021_create_income_details_table.php
+++ b/database/migrations/2024_12_20_172021_create_income_details_table.php
@@ -13,7 +13,14 @@ return new class extends Migration
     {
         Schema::create('income_details', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('income_id');
+            $table->unsignedBigInteger('item_id');
+            $table->integer('quantity');
+            $table->decimal('price', 11, 2);
             $table->timestamps();
+
+            $table->foreign('income_id')->references('id')->on('incomes');
+            $table->foreign('item_id')->references('id')->on('items');
         });
     }
 

--- a/database/migrations/2024_12_20_172928_create_sales_table.php
+++ b/database/migrations/2024_12_20_172928_create_sales_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sales', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sales');
+    }
+};

--- a/database/migrations/2024_12_20_172928_create_sales_table.php
+++ b/database/migrations/2024_12_20_172928_create_sales_table.php
@@ -13,7 +13,17 @@ return new class extends Migration
     {
         Schema::create('sales', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('customer_id');
+            $table->string('receipt_type', 20);
+            $table->string('receipt_series', 7)->nullable();
+            $table->string('receipt_number', 10);
+            $table->dateTime('date_time');
+            $table->decimal('tax', 4, 2);
+            $table->decimal('total_sale', 11, 2);
+            $table->boolean('status')->default(1);
             $table->timestamps();
+
+            $table->foreign('customer_id')->references('id')->on('customers');
         });
     }
 

--- a/database/migrations/2024_12_20_173036_create_sale_details_table.php
+++ b/database/migrations/2024_12_20_173036_create_sale_details_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sale_details', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sale_details');
+    }
+};

--- a/database/migrations/2024_12_20_173036_create_sale_details_table.php
+++ b/database/migrations/2024_12_20_173036_create_sale_details_table.php
@@ -13,7 +13,15 @@ return new class extends Migration
     {
         Schema::create('sale_details', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('sale_id');
+            $table->unsignedBigInteger('item_id');
+            $table->integer('quantity');
+            $table->decimal('price', 11, 2);
+            $table->decimal('discount', 11, 2)->nullable();
             $table->timestamps();
+
+            $table->foreign('sale_id')->references('id')->on('sales');
+            $table->foreign('item_id')->references('id')->on('items');
         });
     }
 


### PR DESCRIPTION
## Pull Request Summary

💾  **Contacts Table Migration**: Added rollback migration for the `contacts` table and implemented rollback logic. Added migration for creating the `contacts` table with drop and create logic.

💾  **Customers and Suppliers Tables**: Added migrations for creating `customers` and `suppliers` tables. Included fields in the migrations for both tables.

💾  **Incomes and Income Details Tables**: Added migrations for creating `incomes` and `income_details` tables. Included fields and foreign key constraints for `supplier_id` in the `incomes` table and `income_id` and `item_id` in the `income_details` table.

💾  **Sales and Sale Details Tables**: Added migrations for creating `sales` and `sale_details` tables. Included `customer_id` and additional fields with foreign key constraints in the `sales` table, and `sale_id` and `item_id` fields with foreign key constraints in the `sale_details` table.

:gear: **Database Schema Enhancements**: Enhanced the database schema with new tables and fields to support contacts, customers, suppliers, incomes, and sales.
